### PR TITLE
fix: add missing config properties for BranchGraphValidator

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,9 @@ export interface BranchThinkingConfig {
       good: number;
       moderate: number;
     };
+    maxContentLength: number;
+    maxTraversalDepth: number;
+    maxResultCount: number;
   };
   
   branch: {
@@ -136,7 +139,10 @@ export const DEFAULT_CONFIG: BranchThinkingConfig = {
       excellent: 0.75,
       good: 0.55,
       moderate: 0.35
-    }
+    },
+    maxContentLength: 10000,
+    maxTraversalDepth: 1000,
+    maxResultCount: 1000
   },
   
   branch: {


### PR DESCRIPTION
### **User description**
Fixes #37

Added missing TypeScript config properties to resolve compilation errors:
- maxContentLength: number (default 10000)
- maxTraversalDepth: number (default 1000)
- maxResultCount: number (default 1000)

These properties were referenced in BranchGraphValidator.ts but not defined in the BranchThinkingConfig interface, causing TypeScript errors when running `npm run typecheck`.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing TypeScript config properties to BranchThinkingConfig

- Resolve compilation errors in BranchGraphValidator.ts

- Define maxContentLength, maxTraversalDepth, and maxResultCount defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BranchThinkingConfig interface"] --> B["Add missing properties"]
  B --> C["maxContentLength: 10000"]
  B --> D["maxTraversalDepth: 1000"] 
  B --> E["maxResultCount: 1000"]
  C --> F["Fix TypeScript compilation"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Add missing evaluation config properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.ts

<ul><li>Add three missing properties to BranchThinkingConfig interface<br> <li> Define default values in DEFAULT_CONFIG object<br> <li> Properties: maxContentLength (10000), maxTraversalDepth (1000), <br>maxResultCount (1000)</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/branch-thinking/pull/39/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

