### PR TITLE
Fix: Restore fallback logic for maxContentLength in BranchGraphValidator

### DIFF
--- a/src/BranchGraphValidator.ts
+++ b/src/BranchGraphValidator.ts
@@ -135,7 +135,7 @@ export class BranchGraphValidator {
     }
 
     const config = getConfig();
-    const maxLength = config.evaluation.maxContentLength;
+    const maxLength = config?.evaluation?.maxContentLength ?? 10000;
     
     if (trimmedContent.length > maxLength) {
       throw new ValidationError(


### PR DESCRIPTION
Fixes #53

This PR restores the missing fallback logic for `maxContentLength` in the `BranchGraphValidator` to prevent runtime errors when the configuration is incomplete.

## Changes
- Added optional chaining and nullish coalescing to safely access `config.evaluation.maxContentLength`
- Default to 10000 when the value is undefined
- Prevents `TypeError: Cannot read properties of undefined` crashes
- Maintains backwards compatibility with expected behavior

Generated with [Claude Code](https://claude.ai/code)