### PR TITLE
fix: restore optional chaining for threshold check in PruneCommand

### DIFF
--- a/src/commands/PruneCommand.ts
+++ b/src/commands/PruneCommand.ts
@@ -3,7 +3,7 @@ import { getConfig } from '../config.js';
 
 export class PruneCommand extends Command {
   async execute(data: CommandData): Promise<CommandResult> {
-    const threshold = (data.data && data.data.threshold) || getConfig().branch.pruneThreshold;
+    const threshold = data.data?.threshold || getConfig().branch.pruneThreshold;
     
     try {
       const result = await this.branchManager.pruneLowScoringBranches(threshold);

--- a/src/commands/PruneCommand.ts
+++ b/src/commands/PruneCommand.ts
@@ -3,7 +3,7 @@ import { getConfig } from '../config.js';
 
 export class PruneCommand extends Command {
   async execute(data: CommandData): Promise<CommandResult> {
-    const threshold = data.data?.threshold || getConfig().branch.pruneThreshold;
+    const threshold = data.data?.threshold ?? getConfig().branch.pruneThreshold;
     
     try {
       const result = await this.branchManager.pruneLowScoringBranches(threshold);


### PR DESCRIPTION
### **User description**
Replace verbose `(data.data && data.data.threshold)` with idiomatic `data.data?.threshold` for better readability and consistency with TypeScript best practices.

Fixes #55

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace verbose null check with optional chaining operator

- Improve code readability in threshold parameter handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["data.data && data.data.threshold"] -- "refactor" --> B["data.data?.threshold"]
  B --> C["Improved readability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PruneCommand.ts</strong><dd><code>Use optional chaining for threshold check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commands/PruneCommand.ts

<ul><li>Replace <code>(data.data && data.data.threshold)</code> with <code>data.data?.threshold</code><br> <li> Maintain same functionality with cleaner syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/branch-thinking/pull/56/files#diff-93d5062b606dadaa36d1b7d4eb4192b4d51e943693457385e7f2b3eaf0aff48f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

